### PR TITLE
Guard the assetstoreImportViewMap update

### DIFF
--- a/girder_assetstore/web_client/views/ImportView.js
+++ b/girder_assetstore/web_client/views/ImportView.js
@@ -104,6 +104,9 @@ const GirderAssetstoreImportView = View.extend({
     }
 });
 
-assetstoreImportViewMap[AssetstoreType.GIRDER] = GirderAssetstoreImportView;
+// This can be null if the base view is not the main Girder application
+if (assetstoreImportViewMap) {
+    assetstoreImportViewMap[AssetstoreType.GIRDER] = GirderAssetstoreImportView;
+}
 
 export default GirderAssetstoreImportView;


### PR DESCRIPTION
We can only set the assetstoreImportViewMap if the main Girder application exists.